### PR TITLE
ASNBlock: Query only first range address in RIPEstat WHOIS lookup

### DIFF
--- a/src/asnblock.py
+++ b/src/asnblock.py
@@ -48,7 +48,7 @@ from typing import (
     Sequence,
 )
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 logger = utils.getInitLogger(
     "ASNBlock", level="VERBOSE", filename="stderr", thread=True
@@ -366,7 +366,7 @@ def search_ripestat_whois(
         throttle.throttle()
 
     try:
-        data = query_ripestat("whois", False, resource=str(net)).get("data", {})
+        data = query_ripestat("whois", False, resource=str(net[0])).get("data", {})
     except requests.exceptions.HTTPError as e:
         logger.warning(e, exc_info=True)
         return None


### PR DESCRIPTION
RIPEstat supports range WHOIS lookups, but if the requested range is
larger than the WHOIS range, it will return results for a larger range.
That means that the WHOIS filtering is less specific. Requesting only
the first address will give the result for the first WHOIS range in the
range we're looking at.

In the future, it may be useful to iterate through all the WHOIS results
in the range based on the `inetnum` value, and only include the
sub-ranges matching a result. That would substantially increase the
un-cached WHOIS lookup time.