### PR TITLE
ASNBlock: use concurrencyPolicy: Replace and set activeDeadlineSeconds

### DIFF
--- a/etc/asnblock_cron.yaml
+++ b/etc/asnblock_cron.yaml
@@ -8,11 +8,12 @@ metadata:
     toolforge: tool
 spec:
   schedule: "30 2 * * *"
-  concurrencyPolicy: Forbid
+  concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 2
   jobTemplate:
     spec:
       backoffLimit: 0
+      activeDeadlineSeconds: 28800
       template:
         metadata:
           labels:


### PR DESCRIPTION
Sometimes the ASNBlock job gets stuck, which prevents it from running
for days. With these settings, the job will fail after 8 hours and will
be restarted the next day.