### PR TITLE
catcron: fix schedule

### DIFF
--- a/etc/catcron_cron.yaml
+++ b/etc/catcron_cron.yaml
@@ -7,7 +7,7 @@ metadata:
     name: anticompositebot.catcron
     toolforge: tool
 spec:
-  schedule: "30 12 ** *"
+  schedule: "30 12 * * *"
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 1
   jobTemplate:


### PR DESCRIPTION
```
The CronJob "anticompositebot.catcron" is invalid: spec.schedule: Invalid value: "30 12 ** *": Expected exactly 5 fields, found 4: 30 12 ** *
```