### PR TITLE
fix bad exception reference in api_get_usage

### DIFF
--- a/src/ShouldBeSVG.py
+++ b/src/ShouldBeSVG.py
@@ -126,7 +126,7 @@ def api_get_usage(cat: pywikibot.Category, depth: int, total: int) -> UsageResul
                 try:
                     usage = pywikibot.FilePage.globalusage(page)
                     usage_counts.append(FileUsage(page.title(), len(list(usage))))
-                except (pywikibot.NoUsername, pywikibot.PageRelatedError):
+                except (pywikibot.NoUsernameError, pywikibot.PageRelatedError):
                     # Pywikibot complains if the bot doesn't have an account
                     # on a wiki where a file is used. If that happens,
                     # skip the file.


### PR DESCRIPTION
```
2022-11-03 18:11:44 ShouldBeSVG ERROR: module 'pywikibot' has no attribute 'NoUsername'
Traceback (most recent call last):
  File "/data/project/anticompositebot/AntiCompositeBot/src/ShouldBeSVG.py", line 54, in get_usage
    usage = db_get_usage(cat, depth)
  File "/data/project/anticompositebot/AntiCompositeBot/src/ShouldBeSVG.py", line 74, in db_get_usage
    conn = toolforge.connect("commonswiki")
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/toolforge/__init__.py", line 49, in connect
    return _connect(
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/toolforge/__init__.py", line 63, in _connect
    return pymysql.connect(*args, **kw)
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pymysql/connections.py", line 353, in __init__
    self.connect()
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pymysql/connections.py", line 632, in connect
    self._get_server_information()
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pymysql/connections.py", line 1055, in _get_server_information
    packet = self._read_packet()
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pymysql/connections.py", line 692, in _read_packet
    packet_header = self._read_bytes(4)
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pymysql/connections.py", line 748, in _read_bytes
    raise err.OperationalError(
pymysql.err.OperationalError: (2013, 'Lost connection to MySQL server during query')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/project/anticompositebot/AntiCompositeBot/src/ShouldBeSVG.py", line 128, in api_get_usage
    usage_counts.append(FileUsage(page.title(), len(list(usage))))
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/site/_extensions.py", line 227, in globalusage
    gu_site = pywikibot.Site(url=entry['url'])
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/__init__.py", line 1070, in Site
    code, fam = _code_fam_from_url(url, fam)
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/__init__.py", line 981, in _code_fam_from_url
    code = family.from_url(url)
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/family.py", line 658, in from_url
    for iw_url in site._interwiki_urls():
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/site/_basesite.py", line 236, in _interwiki_urls
    yield self.articlepath
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/site/_apisite.py", line 672, in articlepath
    path = self.siteinfo['general']['articlepath']
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/site/_siteinfo.py", line 253, in __getitem__
    return self.get(key, False)  # caches and doesn't force it
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/site/_siteinfo.py", line 304, in get
    preloaded = self._get_general(key, expiry)
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/site/_siteinfo.py", line 242, in _get_general
    default_info = self._get_siteinfo(props, expiry)
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/site/_siteinfo.py", line 167, in _get_siteinfo
    data = request.submit()
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/data/api/_requests.py", line 1258, in submit
    self._data = super().submit()
  File "/data/project/anticompositebot/AntiCompositeBot/venv/lib/python3.9/site-packages/pywikibot/data/api/_requests.py", line 1075, in submit
    raise NoUsernameError('Failed OAuth authentication for {}: {}'
pywikibot.exceptions.NoUsernameError: Failed OAuth authentication for wikipedia:ary: The authorization headers in your request are for a user that does not exist here

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/project/anticompositebot/AntiCompositeBot/src/ShouldBeSVG.py", line 279, in <module>
    main()
  File "/data/project/anticompositebot/AntiCompositeBot/src/ShouldBeSVG.py", line 266, in main
    usage_result = get_usage(cat, depth, args.total)
  File "/data/project/anticompositebot/AntiCompositeBot/src/ShouldBeSVG.py", line 56, in get_usage
    usage = api_get_usage(cat, depth, total)
  File "/data/project/anticompositebot/AntiCompositeBot/src/ShouldBeSVG.py", line 129, in api_get_usage
    except (pywikibot.NoUsername, pywikibot.PageRelatedError):
AttributeError: module 'pywikibot' has no attribute 'NoUsername'

```