### PR TITLE
Catwatch: move to 08:00 UTC

### DIFF
--- a/etc/catwatch_cron.yaml
+++ b/etc/catwatch_cron.yaml
@@ -7,7 +7,7 @@ metadata:
     # The toolforge=tool label will cause $HOME and other paths to be mounted from Toolforge
     toolforge: tool
 spec:
-  schedule: "0 0 * * *"
+  schedule: "0 8 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 0
   jobTemplate:


### PR DESCRIPTION
No particular need to run at midnight, and the k8s cluster is struggling then.