### PR TITLE
Bump ASNBlock job memory quota request to 4Gi

### DIFF
--- a/etc/asnblock_cron.yaml
+++ b/etc/asnblock_cron.yaml
@@ -34,4 +34,7 @@ spec:
             - name: LOG_SMTP
               value: "True"
             imagePullPolicy: Always
+            resources:
+              requests:
+                cpu: 4Gi
           restartPolicy: Never


### PR DESCRIPTION
It's OOMing and I would like it to stop doing that.

Fixes #261