### PR TITLE
essayassesment: pagelinks table normalization

### DIFF
--- a/src/essayassesment.py
+++ b/src/essayassesment.py
@@ -60,7 +60,8 @@ class Essay:
         query = """
         SELECT COUNT(pl_from)
         FROM pagelinks
-        WHERE pl_title = %s and pl_namespace = %s"""
+        JOIN linktarget ON pl_target_id = lt_id
+        WHERE lt_title = %s and lt_namespace = %s"""
         conn = toolforge.connect("enwiki_p")
         with conn.cursor() as cur:
             cur.execute(


### PR DESCRIPTION
The pl_title and pl_namespace fields are currently being removed from the databases.

Issue:  #109