### PR TITLE
Revert "ASNBlock: disable global report due to T371437"

### DIFF
--- a/etc/asnblock_cron.yaml
+++ b/etc/asnblock_cron.yaml
@@ -26,7 +26,7 @@ spec:
               "/data/project/anticompositebot/AntiCompositeBot/venv/bin/python3",
               "/data/project/anticompositebot/AntiCompositeBot/src/asnblock.py"
             ]
-            args: ["enwiki", "enwiki=30"]
+            args: ["enwiki", "enwiki=30", "centralauth"]
             workingDir: /data/project/anticompositebot
             env:
             - name: HOME


### PR DESCRIPTION
This reverts commit a8a812101bcf29ec81b1b97808402be46bfc65e8.